### PR TITLE
Bug: ColWidth_Converter wasn't imported

### DIFF
--- a/mkdocs_glossary_plugin/converter/DoubleConverter.py
+++ b/mkdocs_glossary_plugin/converter/DoubleConverter.py
@@ -14,5 +14,8 @@ class DoubleConverter(BaseConverter):
     def __init__(self: "DoubleConverter") -> None:
         pass
 
+    def convert(self: "DoubleConverter", context: Context, target: Double) -> List[Any]:
+        return [target]
+
 
 CONVERTER_TABLE[Double] = DoubleConverter()

--- a/mkdocs_glossary_plugin/converter/__init__.py
+++ b/mkdocs_glossary_plugin/converter/__init__.py
@@ -22,6 +22,7 @@ from . import ColSpanConverter
 from . import ColSpecConverter
 from . import ColWidthConverter
 from . import ColWidthDefaultConverter
+from . import ColWidth_Converter
 from . import DecimalConverter
 from . import DefaultDelimConverter
 from . import DefaultStyleConverter


### PR DESCRIPTION
ColWidth_Converter was not added to __init__.py that leads to error:

```
    converted = CONVERTER_TABLE[type(child)].convert(context, child)
KeyError: ColWidth_(Double)
```

The commit also fixes DoubleConverter which is never used so no one see an error:

```
    for child_index, child in enumerate(target):
TypeError: 'float' object is not iterable
```